### PR TITLE
Add OpenFBX CMake consumer test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,9 @@ test:
     - ctest --test-dir tests\\build --output-on-failure -C Release  # [win]
   requires:
     - cmake
+    - {{ compiler('cxx') }}
     - ninja  # [not win]
+    - {{ stdlib('c') }}
   files:
     - tests/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
   - url: https://github.com/nem0/OpenFBX/archive/v{{ version }}.tar.gz
@@ -27,7 +27,18 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/share/openfbx/openfbxConfig.cmake  # [not win]
+    - cmake -S tests -B tests/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PREFIX  # [not win]
+    - cmake --build tests/build --config Release  # [not win]
+    - ctest --test-dir tests/build --output-on-failure  # [not win]
     - if not exist %PREFIX%\\Library\\share\\openfbx\\openfbxConfig.cmake exit 1  # [win]
+    - cmake -S tests -B tests\\build -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%  # [win]
+    - cmake --build tests\\build --config Release  # [win]
+    - ctest --test-dir tests\\build --output-on-failure -C Release  # [win]
+  requires:
+    - cmake
+    - ninja  # [not win]
+  files:
+    - tests/
 
 about:
   home: https://github.com/nem0/OpenFBX

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.11)
+
+project(openfbx_consumer LANGUAGES CXX)
+
+include(CTest)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(openfbx CONFIG REQUIRED)
+
+add_executable(openfbx_consumer main.cpp)
+target_link_libraries(openfbx_consumer PRIVATE OpenFBX)
+add_test(NAME openfbx_consumer COMMAND openfbx_consumer)

--- a/recipe/tests/main.cpp
+++ b/recipe/tests/main.cpp
@@ -1,0 +1,23 @@
+#include <ofbx.h>
+
+#include <cmath>
+
+int main()
+{
+    const double seconds = 1.25;
+    const auto ticks = ofbx::secondsToFbxTime(seconds);
+    const double roundtrip = ofbx::fbxTimeToSeconds(ticks);
+
+    if (std::abs(roundtrip - seconds) > 1e-9)
+    {
+        return 1;
+    }
+
+    const auto flags = ofbx::LoadFlags::IGNORE_GEOMETRY | ofbx::LoadFlags::IGNORE_LIGHTS;
+    if (static_cast<ofbx::u16>(flags) == 0)
+    {
+        return 2;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a recipe-local downstream CMake consumer test using `find_package(openfbx CONFIG REQUIRED)` and the exported `OpenFBX` target
- run the consumer through CTest on Unix and Windows package tests
- quote the package version so `conda-smithy recipe-lint` does not parse `0.9` as a YAML float

## Validation
- `git diff --check`
- `conda-smithy recipe-lint --conda-forge recipe`

This is test/lint cleanup only, so there is no build-number bump. Keeping this draft until CI proves the current head.